### PR TITLE
Merging upstream changes from pytube v11.0.1 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.0.0
+current_version = 11.0.1
 commit = True
 tag = True
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -41,7 +41,9 @@ when you create a YouTube object::
             'http://youtube.com/watch?v=2lAe1cqCOXo',
             on_progress_callback=progress_func,
             on_complete_callback=complete_func,
-            proxies=my_proxies
+            proxies=my_proxies,
+            use_oauth=False,
+            allow_oauth_cache=True
         )
 
 When instantiating a YouTube object, these named arguments can be passed in to
@@ -56,6 +58,13 @@ The on_complete_callback function will run after a video has been fully
 downloaded, and is called with two arguments: the stream and the file path.
 This could be used, for example, to perform post-download processing on a video
 like trimming the length of it.
+
+The use_oauth and allow_oauth_cache flags allow you to authorize pytube to
+interact with YouTube using your account, and can be used to bypass age
+restrictions or access private videos and playlists. If allow_oauth_cache is
+set to True, you should only be prompted to do so once, after which point
+pytube will cache the tokens it needs to act on your behalf. Otherwise, you
+will be prompted again for each action that requires you to be authenticated.
 
 Once you have a YouTube object set up, you're ready to start looking at
 different media streams for the video, which is discussed in the next section.

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -43,7 +43,14 @@ class YouTube:
         :param func on_complete_callback:
             (Optional) User defined callback function for stream download
             complete events.
-
+        :param dict proxies:
+            (Optional) A dict mapping protocol to proxy address which will be used by pytube.
+        :param bool use_oauth:
+            (Optional) Prompt the user to authenticate to YouTube.
+            If allow_oauth_cache is set to True, the user should only be prompted once.
+        :param bool allow_oauth_cache:
+            (Optional) Cache OAuth tokens locally on the machine. Defaults to True.
+            These tokens are only generated if use_oauth is set to True as well.
         """
         self._js: Optional[str] = None  # js fetched by js_url
         self._js_url: Optional[str] = None  # the url to the js, parsed from watch html

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -265,7 +265,7 @@ def get_throttling_function_name(js: str) -> str:
         # https://github.com/ytdl-org/youtube-dl/issues/29326#issuecomment-865985377
         # a.C&&(b=a.get("n"))&&(b=Dea(b),a.set("n",b))}};
         # In above case, `Dea` is the relevant function name
-        r'a\.C&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\),a\.set\("n",b\)\)}};',
+        r'a\.[A-Z]&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\)',
     ]
     logger.debug('Finding throttling function name')
     for pattern in function_patterns:

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -319,18 +319,26 @@ class Playlist(Sequence):
     def last_updated(self) -> Optional[date]:
         """Extract the date that the playlist was last updated.
 
-        :return: Date of last playlist update
+        For some playlists, this will be a specific date, which is returned as a datetime
+        object. For other playlists, this is an estimate such as "1 week ago". Due to the
+        fact that this value is returned as a string, pytube does a best-effort parsing
+        where possible, and returns the raw string where it is not possible.
+
+        :return: Date of last playlist update where possible, else the string provided
         :rtype: datetime.date
         """
         last_updated_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
             'stats'][2]['runs'][1]['text']
-        date_components = last_updated_text.split()
-        month = date_components[0]
-        day = date_components[1].strip(',')
-        year = date_components[2]
-        return datetime.strptime(
-            f"{month} {day:0>2} {year}", "%b %d %Y"
-        ).date()
+        try:
+            date_components = last_updated_text.split()
+            month = date_components[0]
+            day = date_components[1].strip(',')
+            year = date_components[2]
+            return datetime.strptime(
+                f"{month} {day:0>2} {year}", "%b %d %Y"
+            ).date()
+        except (IndexError, KeyError):
+            return last_updated_text
 
     @property
     @cache

--- a/pytube/contrib/search.py
+++ b/pytube/contrib/search.py
@@ -18,7 +18,7 @@ class Search:
             Search query provided by the user.
         """
         self.query = query
-        self._innertube_client = InnerTube()
+        self._innertube_client = InnerTube(client='WEB')
 
         # The first search, without a continuation, is structured differently
         #  and contains completion suggestions, so we must store this separately

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "11.0.0"
+__version__ = "11.0.1"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Merging upstream changes from pytube v11.0.1 
https://github.com/pytube/pytube/releases/tag/v11.0.1
> Fixes RegexMatchError in n cipher
> Added documentation for some new functionality
> last_updated will now return the raw text if it can't parse a datetime (e.g. "X days ago")
> change default innertube client for Search objects to WEB

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> pytube#1098
> pytube#1099

## Security Impacts
> None

## Checklists

### Development

- [X] All tests related to the changed code pass in development

### Code review 

- [X]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [X] Changes have been reviewed by at least one other engineer
